### PR TITLE
Fix function mismatch when header contains comments

### DIFF
--- a/src/FunctionDetails.ts
+++ b/src/FunctionDetails.ts
@@ -83,7 +83,6 @@ export default class FunctionDetails {
      * @param source
      */
     public static parseFunctions(source:string) : Array<FunctionDetails> {
-        source = source.replace(/\/\/[^\n^\r]+/g, '');
         let result:FunctionDetails[] = [];
         let templateRegex = Helpers.templateRegex;
         let attributeRegex = "(\\[\\[[^\\]]+\\]\\])*";


### PR DESCRIPTION
This PR fixes an issue where the implementation of the wrong function is generated (or the function wasn't found at all) in some cases when the header file contains comments. Tested this in several scenarios and it seems to work, but note that comments for parameters are now preserved. Please let me know if this solution proposes undesired behavior, so I can adjust it since this issue currently makes this (awesome) extension unusable for me :)
Fixes #49 partially (only for line comments)
Issue:

![Animation (1)](https://user-images.githubusercontent.com/50084500/146644504-41a0d594-ad23-49f0-a786-ef63107d99aa.gif)

This PR:

![Animation2](https://user-images.githubusercontent.com/50084500/146644420-f0b9874b-3fde-40b2-8271-5a09cd68ccf2.gif)

