### PR TITLE
Adding support for find/replace config that allows alternative directory structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Show or hide "Create Header Guard" in context menu.
 What happen if source file of a header file not found.
 * Implement in same file
 * Create source file
+* Show error
+* Do nothing
 
 ## Known Issues
 If you implement a previously implemented function duplicate implementation will happen.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,9 @@
 						"type": "string",
 						"enum": [
 							"Implement in same file",
-							"Create source file"
+							"Create source file",
+							"Show error",
+							"Do nothing"
 						],
 						"default": "Implement in same file",
 						"description": "What happen if source file of a header file not found."

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 							"required": ["find", "replace"]
 						},
 						"default": [
-							{ "find":"Public", "replace": "Private" }
+							{ "find":"\\Public\\", "replace": "\\Private\\" }
 						],
 						"description": "Pairs of strings to find/replace within the path"
 					},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cpp-helper",
 	"displayName": "C++ Helper",
 	"description": "Create implementation for c++ function prototypes.",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"icon": "images/icon.png",
 	"publisher": "amiralizadeh9480",
 	"engines": {
@@ -95,6 +95,25 @@
 							"/source/{FILE}.c"
 						],
 						"description": "Source file pattern for headers."
+					},
+					"CppHelper.FindReplaceStrings": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"find": {
+									"type": "string"
+								},
+								"replace": {
+									"type": "string"
+								}
+							},
+							"required": ["find", "replace"]
+						},
+						"default": [
+							{ "find":"Public", "replace": "Private" }
+						],
+						"description": "Pairs of strings to find/replace within the path"
 					},
 					"CppHelper.HeaderGuardPattern": {
 						"type": "string",

--- a/src/FunctionDetails.ts
+++ b/src/FunctionDetails.ts
@@ -93,6 +93,8 @@ export default class FunctionDetails {
 
         source = source.replace(/\/\/[^\r\n]+/g, ss => '#'.repeat(ss ? ss.length : 1));
         source = source.replace(/\/\*\*[\s\S]+(?=\*\/)\*\//g, ss => ss.replace(/[^\r\n]+/g, sss => '#'.repeat(sss ? sss.length : 1) + '\n'));
+        // Strip Unreal Engine specifiers so they don't break parsing and crash VSCode
+        source = source.replace(/(UCLASS|UPROPERTY|UFUNCTION|UINTERFACE|UENUM|USTRUCT)[^\r\n]+/g, ss => '#'.repeat(ss ? ss.length : 1));
         let funcRegexStr = templateRegex + attributeRegex + '\\s+' + returnTypeRegex + '\\s+' + funcRegex + '\\s*' + funcParamsRegex + '\\s*' + afterParamsRegex;
         let regex = new RegExp(funcRegexStr, 'gm');
         let match = null, match2 = null;

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -112,11 +112,15 @@ export default class Helpers {
 
                 if (notFoundBehavior === 'Create source file' && extension?.toLowerCase() !== 'cpp') {
                     let workspaceEdit = new vscode.WorkspaceEdit;
-                    workspaceEdit.createFile(vscode.Uri.file(directory + '/' + name + '.cpp'), {overwrite: false, ignoreIfExists: true});
+                    let newdirectory = directory;
+                    replacements.forEach(pair => {
+                        newdirectory = newdirectory.replace(pair.find, pair.replace);
+                    });
+                    workspaceEdit.createFile(vscode.Uri.file(newdirectory + '/' + name + '.cpp'), {overwrite: false, ignoreIfExists: true});
                     return vscode.workspace.applyEdit(workspaceEdit)
                         .then(function (result: boolean) {
                             if (result) {
-                                return vscode.workspace.openTextDocument(directory + '/' + name + '.cpp')
+                                return vscode.workspace.openTextDocument(newdirectory + '/' + name + '.cpp')
                                     .then((doc: vscode.TextDocument) => {
                                         vscode.window.showTextDocument(doc, 1, true)
                                             .then(function (textEditor: vscode.TextEditor) {
@@ -131,9 +135,10 @@ export default class Helpers {
                                 resolve(vscode.window.activeTextEditor);
                             }
                         });
-                } else if (vscode.window.activeTextEditor) {
+                } else if (notFoundBehavior === "Implement in same file" && vscode.window.activeTextEditor) {
                     resolve(vscode.window.activeTextEditor);
                 }
+                reject("Could not find or create matching source file");
             }
         });
     }

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -70,6 +70,7 @@ export default class Helpers {
      */
     public static openSourceFile(): Promise<vscode.TextEditor> {
         let patterns: any = vscode.workspace.getConfiguration("CppHelper").get<Array<string>>('SourcePattern');
+        let replacements: Array<{find:string, replace:string}> = vscode.workspace.getConfiguration("CppHelper").get("FindReplaceStrings") as Array<{find:string, replace:string}>;
         let notFoundBehavior: any = vscode.workspace.getConfiguration("CppHelper").get<string>('SourceNotFoundBehavior');
         return new Promise(function (resolve, reject) {
             let fileName = vscode.window.activeTextEditor?.document.fileName;
@@ -85,6 +86,9 @@ export default class Helpers {
                         } else {
                             fileToOpen = path.join(directory, patterns[i].replace('{FILE}', name));
                         }
+                        replacements.forEach(pair => {
+                            fileToOpen = fileToOpen.replace(pair.find, pair.replace);
+                        });
                         if (fs.existsSync(fileToOpen)) {
                             for (let i in vscode.window.visibleTextEditors) {
                                 let textEditor : vscode.TextEditor = vscode.window.visibleTextEditors[i];

--- a/src/commands/CreateImplementation.ts
+++ b/src/commands/CreateImplementation.ts
@@ -115,9 +115,17 @@ export default function () {
             var activeEditor = vscode.window.activeTextEditor;
             var selections = activeEditor.selections;
             selections = selections.sort((a:vscode.Selection, b: vscode.Selection) => a.start.isAfter(b.start) ? 1 : -1);
-            Helpers.openSourceFile().then(function (doc : vscode.TextEditor) {
+            Helpers.openSourceFile()
+            .then(function (doc : vscode.TextEditor) {
                 create(activeEditor, selections, doc);
+            })
+            .catch(function (error) {
+                let notFoundBehavior: any = vscode.workspace.getConfiguration("CppHelper").get<string>('SourceNotFoundBehavior');
+                if (notFoundBehavior === "Show error") {
+                    vscode.window.showErrorMessage(error);
+                }
             });
+
         }
     }
 }


### PR DESCRIPTION
I wanted a way to support more configuration for split-directory setups without having to specify every directory.

For Unreal Engine, the structure will often look like this:
\Source\ProjectName\Public\directory\file.h
and the matching source file will look like this:
\Source\ProjectName\Private\directory\file.cpp

I've added a configuration that will do a find and replace in the file path, allowing you to specify your directory structure. The configuration I'm currently using locally looks like this:
`"CppHelper.FindReplaceStrings": [
		{
			"find": "\\Public\\",
			"replace": "\\Private\\"
		}
	],`

With this change, I've now simplified my SourcePattern to look like this:
`"CppHelper.SourcePattern": [
		"{FILE}.cpp",
		"{FILE}.cc",
		"{FILE}.c",
	],`

And it's now able to find all of my source files. (You could also use `{"find": "header", "replace": "source"}` or something similar to replace the rest of the defaults in "CppHelper.SourcePattern")

I'm also using the FindReplaceStrings for determining where to create the matching source file when using "Create source file" for "CppHelper.SourceNotFoundBehavior".

I've also added the ability to do nothing or show an error message if the matching source file can't be found. For Unreal projects, I don't want to automatically create a new source file, and I don't necessarily want to create the implementation in the header either. I do, however, want to see a message that tells me the file wasn't found or created, so I know it's doing something.

Feel free to use any, all, or none of these changes - this is a super handy extension, and these changes made configuration much easier for my Unreal project.